### PR TITLE
Avoid modal content scroll and hide html body overlay

### DIFF
--- a/js/a11y-dialog.js
+++ b/js/a11y-dialog.js
@@ -116,6 +116,9 @@
     document.body.addEventListener('focus', this._maintainFocus, true);
     document.addEventListener('keydown', this._bindKeypress);
 
+    // Add overlay class to document body.
+    document.body.classList.add('has_overlay');
+
     // Execute all callbacks registered for the `show` event
     this._fire('show', event);
 
@@ -176,6 +179,9 @@
     // for specific key presses
     document.body.removeEventListener('focus', this._maintainFocus, true);
     document.removeEventListener('keydown', this._bindKeypress);
+
+    // Remove overlay class to document body.
+    document.body.classList.remove('has_overlay');
 
     // Execute all callbacks registered for the `hide` event
     this._fire('hide', event);

--- a/scss/_modals.scss
+++ b/scss/_modals.scss
@@ -14,6 +14,7 @@
 		left: 160px;
 		display: flex;
 		align-items: center;
+		overflow: auto;
 
 		// Modal sizes.
 		&.sui-dialog-sm {
@@ -108,7 +109,6 @@
 		max-width: 600px;
 		margin: 0 auto;
 		max-height: 85%;
-		overflow-y: auto;
 
 		> .sui-box {
 			box-shadow: 0 10px 40px $modal-box-shadow-color;
@@ -137,5 +137,9 @@
 		color: $modal-close-color;
 		@include icon(before, 'close');
 		outline-style: none;
+	}
+
+	&.has_overlay {
+		overflow: hidden;
 	}
 }


### PR DESCRIPTION
Long modals are [looking weird](http://www.clipular.com/c/4898312424259584.png?k=aFCp30gmUqpqCWCpHPjxuDdg-vk) when scrollbars are added to modal content. Hide document body overlay and add overlay auto to scroll entire modal content without a scrollbar.
