### PR TITLE
Fix/select2 webpack incompatible

### DIFF
--- a/js/select2.full.js
+++ b/js/select2.full.js
@@ -9,10 +9,11 @@
  * For easy debugging process or update upstream of select
  */
 (function (factory) {
-    if (typeof define === 'function' && define.amd) {
+    // SUI-SELECT2 disable AMD and module exports
+    if (false && typeof define === 'function' && define.amd) {
         // AMD. Register as an anonymous module.
         define(['jquery'], factory);
-    } else if (typeof module === 'object' && module.exports) {
+    } else if (false && typeof module === 'object' && module.exports) {
         // Node/CommonJS
         module.exports = function (root, jQuery) {
             if (jQuery === undefined) {
@@ -6511,7 +6512,7 @@
 
     // // Autoload the jQuery bindings
     // // We know that all of the modules exist above this, so we're safe
-    // var select2 = S2.require('jquery.select2');
+    // browserSync = S2.require('jquery.select2');
     //
     // // Hold the AMD module references on the jQuery function that was just loaded
     // // This allows Select2 to use the internal loader outside of this file, such
@@ -6522,6 +6523,7 @@
     // return select2;
 
     // SUI-SELECT2
-    S2.require('sui.select2');
+    var select2 = S2.require('sui.select2');
+    return select2;
 }));
 

--- a/js/select2.full.js
+++ b/js/select2.full.js
@@ -6512,7 +6512,7 @@
 
     // // Autoload the jQuery bindings
     // // We know that all of the modules exist above this, so we're safe
-    // browserSync = S2.require('jquery.select2');
+    // var select2 = S2.require('jquery.select2');
     //
     // // Hold the AMD module references on the jQuery function that was just loaded
     // // This allows Select2 to use the internal loader outside of this file, such


### PR DESCRIPTION
Select2 form the upstream is supporting AMD and CommonJS loader with a _quirky_ check code.
But since our (most) plugins and our example plugin is using `Webpack`, it makes Select2 not loaded, because of their shimming module : [https://webpack.js.org/guides/shimming/#other-utilities](https://webpack.js.org/guides/shimming/#other-utilities).
This problem not happening on shared-ui dev since we are using `gulp` not webpack on showcase.