### PR TITLE
Exclude sui-tag from span style in checkbox label

### DIFF
--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -314,7 +314,7 @@
 			@extend %sui-screen-reader-text;
 		}
 
-		span:not(.sui-description) {
+		span:not(.sui-description, .sui-tag) {
 			flex-shrink: 0;
 			position: relative;
 			display: inline-block;
@@ -340,7 +340,7 @@
 			}
 		}
 
-		input:checked + span:not(.sui-description) {
+		input:checked + span:not(.sui-description, .sui-tag) {
 			border: 1px solid $checkbox-radio-active-color;
 			background-color: $checkbox-radio-active-color;
 			&:before {
@@ -363,7 +363,7 @@
 			}
 		}
 
-		input[disabled] + span:not(.sui-description),
+		input[disabled] + span:not(.sui-description, .sui-tag),
 		fieldset[disabled] & + span:not(.sui-description) {
 			cursor: not-allowed;
 			opacity: .5;

--- a/scss/_forms.scss
+++ b/scss/_forms.scss
@@ -364,7 +364,7 @@
 		}
 
 		input[disabled] + span:not(.sui-description, .sui-tag),
-		fieldset[disabled] & + span:not(.sui-description) {
+		fieldset[disabled] & + span:not(.sui-description, .sui-tag) {
 			cursor: not-allowed;
 			opacity: .5;
 		}
@@ -378,7 +378,7 @@
 	.sui-checkbox {
 		@extend %radio-checkbox;
 
-		span:not(.sui-description) {
+		span:not(.sui-description, .sui-tag) {
 			border-radius: 3px;
 		}
 
@@ -390,7 +390,7 @@
 	.sui-radio {
 		@extend %radio-checkbox;
 
-		span:not(.sui-description) {
+		span:not(.sui-description, .sui-tag) {
 			border-radius: 50%;
 		}
 


### PR DESCRIPTION
`sui-tag` classes are not working inside label.

Expected result - http://www.clipular.com/posts/4811512175394816?k=kzG0ss3xZRJyNAeHggrCtZ3c9YU
Current result - http://www.clipular.com/posts/5121137978376192?k=VBX_F3UuTIyeTaEV6-QUtO0hEB8

Asana Task - https://app.asana.com/0/164174452236961/688541614834355/f