### PR TITLE
[Improvement] Selectors box

### DIFF
--- a/index.html
+++ b/index.html
@@ -1165,7 +1165,7 @@ function admin_body_classes( $classes ) {
 
 						</div>
 
-						<div class="sui-box-selectors sui-box-selectors-col-6">
+						<div class="sui-box-selectors sui-box-selectors-col-1">
 
 							<ul>
 
@@ -1209,7 +1209,7 @@ function admin_body_classes( $classes ) {
 
 						</div>
 
-						<div class="sui-box-selectors sui-box-selectors-col-3">
+						<div class="sui-box-selectors sui-box-selectors-col-2">
 
 							<ul>
 
@@ -1274,7 +1274,7 @@ function admin_body_classes( $classes ) {
 
 						</div>
 
-						<div class="sui-box-selectors sui-box-selectors-col-2">
+						<div class="sui-box-selectors sui-box-selectors-col-3">
 
 							<ul>
 
@@ -1317,6 +1317,136 @@ function admin_body_classes( $classes ) {
 									<input type="radio"
 										name="demo-box-selectors--third"
 										id="demo-box-selectors--third-6" />
+									<span>One Column</span>
+								</label></li>
+
+							</ul>
+
+						</div>
+
+						<div class="sui-box-body">
+
+							<div class="sui-box-settings-row">
+
+								<div class="sui-box-settings-col-2">
+
+									<span class="sui-settings-label sui-dark">4 Columns</span>
+									<span class="sui-description">Elements will ocuppy a fourth of a row, allowing a max of 4 elements to be placed per row.</span>
+
+								</div>
+
+							</div>
+
+						</div>
+
+						<div class="sui-box-selectors sui-box-selectors-col-4">
+
+							<ul>
+
+								<li><label for="demo-box-selectors--fourth-1" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fourth"
+										id="demo-box-selectors--fourth-1" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fourth-2" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fourth"
+										id="demo-box-selectors--fourth-2" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fourth-3" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fourth"
+										id="demo-box-selectors--fourth-3" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fourth-4" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fourth"
+										id="demo-box-selectors--fourth-4" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fourth-5" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fourth"
+										id="demo-box-selectors--fourth-5" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fourth-6" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fourth"
+										id="demo-box-selectors--fourth-6" />
+									<span>One Column</span>
+								</label></li>
+
+							</ul>
+
+						</div>
+
+						<div class="sui-box-body">
+
+							<div class="sui-box-settings-row">
+
+								<div class="sui-box-settings-col-2">
+
+									<span class="sui-settings-label sui-dark">5 Columns</span>
+									<span class="sui-description">Elements will ocuppy a fifth of a row, allowing a max of 5 elements to be placed per row.</span>
+
+								</div>
+
+							</div>
+
+						</div>
+
+						<div class="sui-box-selectors sui-box-selectors-col-5">
+
+							<ul>
+
+								<li><label for="demo-box-selectors--fifth-1" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fifth"
+										id="demo-box-selectors--fifth-1" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fifth-2" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fifth"
+										id="demo-box-selectors--fifth-2" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fifth-3" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fifth"
+										id="demo-box-selectors--fifth-3" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fifth-4" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fifth"
+										id="demo-box-selectors--fifth-4" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fifth-5" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fifth"
+										id="demo-box-selectors--fifth-5" />
+									<span>One Column</span>
+								</label></li>
+
+								<li><label for="demo-box-selectors--fifth-6" class="sui-box-selector sui-box-selector-vertical">
+									<input type="radio"
+										name="demo-box-selectors--fifth"
+										id="demo-box-selectors--fifth-6" />
 									<span>One Column</span>
 								</label></li>
 

--- a/scss/_box-selectors.scss
+++ b/scss/_box-selectors.scss
@@ -36,36 +36,20 @@
 			}
 		}
 
-		@for $i from 1 through $box-selectors--total-cols {
-	
-			@if $i != $box-selectors--total-cols {
+		@each $column, $size in $box-selectors--columns {
 
-				$box-selector--col-width: percentage($i / $box-selectors--total-cols);
-	
-				&.sui-box-selectors-col-#{$i} {
-	
-					ul li {
-	
-						@include media(max-width, md) {
-							min-width: 100%;
-							flex-basis: 100%;
-						}
-						
-						@include media(min-width, md) {
-							min-width: $box-selector--col-width;
-							flex-basis: $box-selector--col-width;
-						}
-					}
-				}
-			}
-	
-			@else {
-	
-				&.sui-box-selectors-col-#{$i} {
-	
-					ul li {
+			&.sui-box-selectors-#{$column} {
+
+				ul li {
+
+					@include media(max-width, md) {
 						min-width: 100%;
 						flex-basis: 100%;
+					}
+					
+					@include media(min-width, md) {
+						min-width: $size;
+						flex-basis: $size;
 					}
 				}
 			}

--- a/scss/_box-selectors.scss
+++ b/scss/_box-selectors.scss
@@ -114,7 +114,7 @@
 					width: $box-selector--icon-width;
 					flex: 0 0 $box-selector--icon-width;
 					align-self: flex-start;
-					margin-right: 5px;
+					margin: 0 5px 0 0;
 					font-size: $box-selector--icon-size;
 					text-align: center;
 	
@@ -124,6 +124,13 @@
 						line-height: $box-selector--line-height;
 						transition: $transition;
 					}
+				}
+
+				img {
+					max-width: $box-selector--image-width;
+					height: auto;
+					display: block;
+					margin: 0 5px 0 0;
 				}
 
 				~ span {
@@ -199,6 +206,10 @@
 						&:before {
 							line-height: $box-selector--icon-size;
 						}
+					}
+
+					img {
+						margin: 0 auto;
 					}
 				}
 			}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -194,6 +194,9 @@ $box-selector--line-height-lg:          22px !default;
 $box-selector--icon-width:              30px !default;
 $box-selector--icon-size:               16px !default;
 
+// Item image
+$box-selector--image-width:             24px !default;
+
 // Item ribbon
 // Used as blue triangle on top-right corner when item is selected
 $box-selector--ribbon-height:           80px !default;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -179,7 +179,13 @@ $colorpicker--iris-palette-size:               20px  !default;
 
 // Container
 $box-selectors--spacing:                20px !default;
-$box-selectors--total-cols:             6    !default;
+$box-selectors--columns: (
+	col-1: 100%,
+	col-2: 50%,
+	col-3: 33.33%,
+	col-4: 25%,
+	col-5: 20%
+) !default;
 
 // Item
 $box-selector--height:                  60px !default;


### PR DESCRIPTION
1. Grid supports 4 columns and 5 columns per row.
2. You can use images, instead of icons, if needed (this fix will work for Branda).