### PR TITLE
Remove transition from sortable items - "move" as a event affected by

### DIFF
--- a/scss/_box-builder.scss
+++ b/scss/_box-builder.scss
@@ -154,6 +154,10 @@
 					margin-left: -10px;
 				}
 
+				&.ui-sortable-handle {
+					transition: unset;
+				}
+
 				.sui-builder-field-label {
 
 					&:first-child {


### PR DESCRIPTION
transition with time, causing funny "slow effect".