### PR TITLE
Fix wrong variable in summary box white-labelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v2.9.3
+- [Fix] Summary Box: Wrong variable for white-labelling.
+
+
 v2.9.2
 - [Fix] Modals: Mask not aligned correctly on RTL mode.
 - [Fix] Modals: Lower part of the overlay not closing in long modals.

--- a/assets/scss/shared-ui/_summary.scss
+++ b/assets/scss/shared-ui/_summary.scss
@@ -387,7 +387,7 @@
 
 				@include media(min-width, md) {
 
-					@if variable-exists(summary-image-sm) {
+					@if variable-exists(summary-image) {
 						background-image: unset !important;
 					}
 				}


### PR DESCRIPTION
Instead of `summary-image` variable, we check if `summary-image-sm` exist to hide the default image if rebranding is enabled.