### PR TITLE
Fix/dropdown items fit whole

### DIFF
--- a/assets/css/showcase.css
+++ b/assets/css/showcase.css
@@ -9847,6 +9847,7 @@ fieldset[disabled] .sui-2-10-8 .sui-wrap .sui-multi-checkbox:hover {
 
 .sui-2-10-8 .sui-wrap .sui-dropdown ul {
   min-width: 170px;
+  width:max-content;
   display: none;
   position: absolute;
   z-index: 10;


### PR DESCRIPTION
Fixed a bug where a single item cannot be contained in a single line but rather goes into a new one. Now the dropdown menu stretches to fit the whole item in a single line