### PR TITLE
🐛 fix(modals): Missing class for spacing between icon and title.

### DIFF
--- a/assets/scss/shared-ui/_modals.scss
+++ b/assets/scss/shared-ui/_modals.scss
@@ -124,6 +124,11 @@
 		.sui-box {
 			box-shadow: none;
 
+			// ELEMENT: Icon
+			[class*=sui-icon-] + .sui-box-title{
+				margin-top: 15px;
+			}
+
 			// ELEMENT: Box Title.
 			.sui-box-title {
 


### PR DESCRIPTION
Added CSS in _modal.scss to enhance the spcaing between Icon and heading inside modal to make it 30px.